### PR TITLE
make EnumeratorDataReader internal

### DIFF
--- a/Source/Headspring.BulkWriter/EnumeratorDataReader.cs
+++ b/Source/Headspring.BulkWriter/EnumeratorDataReader.cs
@@ -4,7 +4,7 @@ using System.Data;
 
 namespace Headspring.BulkWriter
 {
-    public sealed class EnumeratorDataReader : IDataReader
+    internal sealed class EnumeratorDataReader : IDataReader
     {
         private readonly IEnumerator enumerator;
         private readonly object firstItem;


### PR DESCRIPTION
I noticed that this class is public when I first started using bulk-writer. Since I don't need to create one, or worry about it (as far as I can tell), I think it should be marked internal. The only public classes IMO are the ones that are created or used by consumers.

Thoughts?
