### PR TITLE
Apply BatchSize and BulkCopyTimeout to underlying SqlBulkCopy object

### DIFF
--- a/src/BulkWriter.Tests/BulkWriterInitializationTests.cs
+++ b/src/BulkWriter.Tests/BulkWriterInitializationTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BulkWriter.Tests
+{
+    public class BulkWriterInitializationTests
+    {
+        private readonly string _connectionString = TestHelpers.ConnectionString;
+        private readonly string _tableName = nameof(BulkWriterInitializationTestsMyTestClass);
+
+        public class BulkWriterInitializationTestsMyTestClass
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        public BulkWriterInitializationTests()
+        {
+            TestHelpers.ExecuteNonQuery(_connectionString, $"DROP TABLE IF EXISTS [dbo].[{_tableName}]");
+
+            TestHelpers.ExecuteNonQuery(_connectionString,
+                "CREATE TABLE [dbo].[" + _tableName + "](" +
+                "[Id] [int] IDENTITY(1,1) NOT NULL," +
+                "[Name] [nvarchar](50) NULL," +
+                "CONSTRAINT [PK_" + _tableName + "] PRIMARY KEY CLUSTERED ([Id] ASC)" +
+                ")");
+        }
+
+        [Fact]
+        public async Task CanSetBulkCopyParameters()
+        {
+            const int timeout = 10;
+            const int batchSize = 1000;
+
+            var writer = new BulkWriter<BulkWriterInitializationTestsMyTestClass>(_connectionString)
+            {
+                BulkCopyTimeout = timeout,
+                BatchSize = batchSize,
+                BulkCopySetup = bcp =>
+                {
+                    Assert.Equal(timeout, bcp.BulkCopyTimeout);
+                    Assert.Equal(batchSize, bcp.BatchSize);
+                }
+            };
+
+            var items = Enumerable.Range(1, 10)
+                .Select(i => new BulkWriterInitializationTestsMyTestClass {Id = i, Name = "Bob"});
+
+            writer.WriteToDatabase(items);
+
+            var count = (int) await TestHelpers.ExecuteScalar(_connectionString, $"SELECT COUNT(1) FROM {_tableName}");
+
+            Assert.Equal(10, count);
+        }
+    }
+}

--- a/src/BulkWriter/BulkWriter.cs
+++ b/src/BulkWriter/BulkWriter.cs
@@ -30,14 +30,6 @@ namespace BulkWriter
                 EnableStreaming = true,
                 BulkCopyTimeout = 0
             };
-            if (BatchSize.HasValue)
-                sqlBulkCopy.BatchSize = BatchSize.Value;
-            if (BulkCopyTimeout.HasValue)
-                sqlBulkCopy.BulkCopyTimeout = BulkCopyTimeout.Value;
-
-            //sqlBulkCopy.BatchSize = BatchSize ?? sqlBulkCopy.BatchSize;
-            //sqlBulkCopy.BulkCopyTimeout = BulkCopyTimeout ?? sqlBulkCopy.BulkCopyTimeout;
-            BulkCopySetup(sqlBulkCopy);
 
             foreach (var propertyMapping in _propertyMappings.Where(propertyMapping => propertyMapping.ShouldMap))
             {
@@ -47,12 +39,24 @@ namespace BulkWriter
             _sqlBulkCopy = sqlBulkCopy;
         }
 
-        public int? BatchSize { get; set; }
-        public int? BulkCopyTimeout { get; set; }
-        public Action<SqlBulkCopy> BulkCopySetup { get; set; } = sbc => {};
- 
+        public int BatchSize
+        {
+            get => _sqlBulkCopy.BatchSize;
+            set => _sqlBulkCopy.BatchSize = value;
+        }
+
+        public int BulkCopyTimeout
+        {
+            get => _sqlBulkCopy.BulkCopyTimeout;
+            set => _sqlBulkCopy.BulkCopyTimeout = value;
+        }
+
+        public Action<SqlBulkCopy> BulkCopySetup { get; set; } = sbc => { };
+
         public void WriteToDatabase(IEnumerable<TResult> items)
         {
+            BulkCopySetup(_sqlBulkCopy);
+
             using (var dataReader = new EnumerableDataReader<TResult>(items, _propertyMappings))
             {
                 _sqlBulkCopy.WriteToServer(dataReader);
@@ -61,6 +65,8 @@ namespace BulkWriter
 
         public async Task WriteToDatabaseAsync(IEnumerable<TResult> items)
         {
+            BulkCopySetup(_sqlBulkCopy);
+
             using (var dataReader = new EnumerableDataReader<TResult>(items, _propertyMappings))
             {
                 await _sqlBulkCopy.WriteToServerAsync(dataReader);


### PR DESCRIPTION
Currently, SqlBulkCopy is not modified by the property-injected properties

There is code in the constructor that looks like it was intended to initialize these properties, but the constructor completes before the properties can be read.

![options_not_applied](https://user-images.githubusercontent.com/389660/31793178-24be05a4-b4e4-11e7-8269-e550d3309b0a.png)

This PR allows full control over SqlBulkCopy and maintains backwards compatibility 