### PR TITLE
Support external SqlConnection and SqlTransaction.

### DIFF
--- a/src/BulkWriter.Tests/TestHelpers.cs
+++ b/src/BulkWriter.Tests/TestHelpers.cs
@@ -31,11 +31,16 @@ CREATE DATABASE [BulkWriter.Tests]");
         {
             using (var sqlConnection = new SqlConnection(connectionString))
             {
-                using (var command = new SqlCommand(commandText, sqlConnection))
-                {
-                    sqlConnection.Open();
-                    return await command.ExecuteScalarAsync();
-                }
+                await sqlConnection.OpenAsync();
+                return await ExecuteScalar(sqlConnection, commandText);
+            }
+        }
+
+        public static async Task<object> ExecuteScalar(SqlConnection sqlConnection, string commandText, SqlTransaction transaction = null)
+        {
+            using (var command = new SqlCommand(commandText, sqlConnection, transaction))
+            {
+                return await command.ExecuteScalarAsync();
             }
         }
 

--- a/src/BulkWriter/BulkWriter.cs
+++ b/src/BulkWriter/BulkWriter.cs
@@ -37,12 +37,11 @@ namespace BulkWriter
             var tableName = tableAttribute?.Name ?? typeof(TResult).Name;
             var destinationTableName = schemaName != null ? $"{schemaName}.{tableName}" : tableName;
 
-            var sqlBulkCopy = new SqlBulkCopy(connectionString, sqlBulkCopyOptions)
-            {
-                DestinationTableName = destinationTableName,
-                EnableStreaming = true,
-                BulkCopyTimeout = 0
-            };
+            var sqlBulkCopy = createBulkCopy(sqlBulkCopyOptions);
+
+            sqlBulkCopy.DestinationTableName = destinationTableName;
+            sqlBulkCopy.EnableStreaming = true;
+            sqlBulkCopy.BulkCopyTimeout = 0;
 
             foreach (var propertyMapping in _propertyMappings.Where(propertyMapping => propertyMapping.ShouldMap))
             {

--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.2.*</Version>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <Authors>Headspring</Authors>
     <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <Summary>LINQ to SQL bulk copy</Summary>

--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.0.2.*</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <Authors>Headspring</Authors>
     <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <Summary>LINQ to SQL bulk copy</Summary>

--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.2.*</VersionPrefix>
     <Authors>Headspring</Authors>
     <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <Summary>LINQ to SQL bulk copy</Summary>

--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <Version>1.0.2.*</Version>
     <Authors>Headspring</Authors>
     <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <Summary>LINQ to SQL bulk copy</Summary>

--- a/src/BulkWriter/Internal/TypeExtensions.cs
+++ b/src/BulkWriter/Internal/TypeExtensions.cs
@@ -16,7 +16,7 @@ namespace BulkWriter.Internal
                     Property = pi,
                     Ordinal = i
                 },
-                ShouldMap = pi.GetCustomAttribute<NotMappedAttribute>() != null,
+                ShouldMap = pi.GetCustomAttribute<NotMappedAttribute>() == null,
                 Destination = new MappingDestination
                 {
                     ColumnName = pi.GetCustomAttribute<ColumnAttribute>()?.Name ?? pi.Name,

--- a/src/BulkWriter/Internal/TypeExtensions.cs
+++ b/src/BulkWriter/Internal/TypeExtensions.cs
@@ -16,7 +16,7 @@ namespace BulkWriter.Internal
                     Property = pi,
                     Ordinal = i
                 },
-                ShouldMap = pi.GetCustomAttribute<NotMappedAttribute>() == null,
+                ShouldMap = pi.GetCustomAttribute<NotMappedAttribute>() != null,
                 Destination = new MappingDestination
                 {
                     ColumnName = pi.GetCustomAttribute<ColumnAttribute>()?.Name ?? pi.Name,


### PR DESCRIPTION
SqlBulkCopy has a constructor that permits a SqlConnection and
SqlTransaction to be provided. Expose this to support applications where
the BulkWriter needs to run in the context of a transaction.