### PR TITLE
Orders by Destination.ColumnOrdinal to work with entities that have [Column(Order=...)] attributes on properties.

### DIFF
--- a/src/BulkWriter/Internal/EnumerableDataReader.cs
+++ b/src/BulkWriter/Internal/EnumerableDataReader.cs
@@ -21,10 +21,10 @@ namespace BulkWriter.Internal
         public EnumerableDataReader(IEnumerable<TResult> items, IEnumerable<PropertyMapping> propertyMappings)
         {
             _items = items ?? throw new ArgumentNullException(nameof(items));
-            _propertyMappings = propertyMappings?.OrderBy(x => x.Source.Ordinal).ToArray() ?? throw new ArgumentNullException(nameof(propertyMappings));
+            _propertyMappings = propertyMappings?.OrderBy(x => x.Destination.ColumnOrdinal).ToArray() ?? throw new ArgumentNullException(nameof(propertyMappings));
 
-            _ordinalToPropertyMappings = _propertyMappings.ToDictionary(x => x.Source.Ordinal);
-            _nameToOrdinalMappings = _propertyMappings.ToDictionary(x => x.Source.Property.Name, x => x.Source.Ordinal);
+            _ordinalToPropertyMappings = _propertyMappings.ToDictionary(x => x.Destination.ColumnOrdinal);
+            _nameToOrdinalMappings = _propertyMappings.ToDictionary(x => x.Source.Property.Name, x => x.Destination.ColumnOrdinal);
         }
 
         public TResult Current


### PR DESCRIPTION
EF Core seems to assign column ordinals alphabetically by property name when creating tables in SQL Server, so the ordinal layout of my EF entities doesn't match their actual column ordinals in the table.

I added [Column(Order=...)] attributes to my properties, but BulkWriter was still failing. My fix was to alter EnumerableDataReader's constructor to order by Destination.ColumnOrdinal instead of Source.Ordinal.

Will you please review and let me know if any changes are necessary?

Thank you,

Jon