### PR TITLE
Add support for `byte[]` fields

### DIFF
--- a/src/BulkWriter.Tests/EnumerableDataReaderTests.cs
+++ b/src/BulkWriter.Tests/EnumerableDataReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using BulkWriter.Internal;
 using Xunit;
 
@@ -26,6 +27,7 @@ namespace BulkWriter.Tests
                 "CREATE TABLE [dbo].[" + _tableName + "](" +
                 "[Id] [int] IDENTITY(1,1) NOT NULL," +
                 "[Name] [nvarchar](50) NULL," +
+                "[Data] [varbinary](max) NULL," +
                 "CONSTRAINT [PK_" + _tableName + "] PRIMARY KEY CLUSTERED ([Id] ASC)" +
                 ")");
 
@@ -70,6 +72,24 @@ namespace BulkWriter.Tests
         }
 
         [Fact]
+        public void GetBytes_Returns_Correct_Value()
+        {
+            var inputBytes = Encoding.UTF8.GetBytes("Michael");
+
+            var element = _enumerable.ElementAt(0);
+            element.Id = 419;
+            element.Data = inputBytes;
+
+            var buffer = new byte[128];
+            const int fieldOffset = 0;
+            const int bufferOffset = 10;
+            var bytesRead = _dataReader.GetBytes(2, fieldOffset, buffer, bufferOffset, buffer.Length - bufferOffset);
+
+            Assert.Equal(bytesRead, inputBytes.Length);
+            Assert.Equal("Michael", Encoding.UTF8.GetString(buffer, bufferOffset, (int) bytesRead));
+        }
+
+        [Fact]
         public void GetName_Returns_Correct_Value()
         {
             Assert.Equal("Id", _dataReader.GetName(0));
@@ -79,14 +99,16 @@ namespace BulkWriter.Tests
         [Fact]
         public void FieldCount_Returns_Correct_Value()
         {
-            Assert.Equal(2, _dataReader.FieldCount);
+            Assert.Equal(3, _dataReader.FieldCount);
         }
-        
+
         public class MyTestClass
         {
             public int Id { get; set; }
 
             public string Name { get; set; }
+
+            public byte[] Data { get; set; }
         }
     }
 }

--- a/src/BulkWriter/Internal/EnumerableDataReader.cs
+++ b/src/BulkWriter/Internal/EnumerableDataReader.cs
@@ -83,6 +83,25 @@ namespace BulkWriter.Internal
             return value;
         }
 
+        public override long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length)
+        {
+            EnsureNotDisposed();
+
+            if (!_ordinalToPropertyMappings.TryGetValue(i, out PropertyMapping mapping))
+            {
+                throw new InvalidOperationException(Resources.EnumerableDataReader_GetValue_OrdinalDoesNotMapToProperty);
+            }
+
+            var valueGetter = mapping.Source.Property.GetValueGetter();
+
+            var value = (byte[])valueGetter(_enumerator.Current);
+            var count = Math.Min(length, value.Length - (int)fieldOffset);
+
+            Buffer.BlockCopy(value, (int)fieldOffset, buffer, bufferoffset, count);
+
+            return count;
+        }
+
         public override string GetName(int i)
         {
             EnsureNotDisposed();
@@ -143,8 +162,6 @@ namespace BulkWriter.Internal
         public override bool GetBoolean(int i) => throw new NotSupportedException();
 
         public override byte GetByte(int i) => throw new NotSupportedException();
-
-        public override long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) => throw new NotSupportedException();
 
         public override char GetChar(int i) => throw new NotSupportedException();
 


### PR DESCRIPTION
`SqlBulkCopy`  uses `DbDataReader`'s `GetBytes` method for `byte[]` values.

This adds support for that in _Bulk Writer_.