### PR TITLE
Add support for overriding SqlBulkCopyOptions in BulkWriter

### DIFF
--- a/src/BulkWriter.Tests/BulkWriterTests.cs
+++ b/src/BulkWriter.Tests/BulkWriterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.SqlClient;
 using System.Linq;
@@ -18,6 +19,14 @@ namespace BulkWriter.Tests
             public string Name { get; set; }
         }
 
+        public class BulkWriterTestsMyTestClassWithKey
+        {
+            [Key]
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
         [Fact]
         public async Task CanWriteSync()
         {
@@ -32,6 +41,28 @@ namespace BulkWriter.Tests
             var count = (int)await TestHelpers.ExecuteScalar(_connectionString, $"SELECT COUNT(1) FROM {tableName}");
 
             Assert.Equal(1000, count);
+        }
+
+        [Fact]
+        public async Task CanWriteSyncWithOptions()
+        {
+            var tableName = DropCreate(nameof(BulkWriterTestsMyTestClass));
+            var tableNameWithKey = DropCreate(nameof(BulkWriterTestsMyTestClassWithKey));
+
+            var writer = new BulkWriter<BulkWriterTestsMyTestClass>(_connectionString);
+            var writerWithOptions = new BulkWriter<BulkWriterTestsMyTestClassWithKey>(_connectionString, SqlBulkCopyOptions.KeepIdentity);
+
+            var items = Enumerable.Range(11, 20).Select(i => new BulkWriterTestsMyTestClass { Id = i, Name = "Bob" });
+            var itemsWithKey = Enumerable.Range(11, 20).Select(i => new BulkWriterTestsMyTestClassWithKey { Id = i, Name = "Bob" });
+
+            writer.WriteToDatabase(items);
+            writerWithOptions.WriteToDatabase(itemsWithKey);
+
+            var minId = (int)await TestHelpers.ExecuteScalar(_connectionString, $"SELECT MIN(Id) FROM {tableName}");
+            var minIdWithKey = (int)await TestHelpers.ExecuteScalar(_connectionString, $"SELECT MIN(Id) FROM {tableNameWithKey}");
+
+            Assert.Equal(1, minId);
+            Assert.Equal(11, minIdWithKey);
         }
 
         [Fact]
@@ -84,6 +115,44 @@ namespace BulkWriter.Tests
                     count = (int)await TestHelpers.ExecuteScalar(connection, $"SELECT COUNT(1) FROM {tableName}");
 
                     Assert.Equal(0, count);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanWriteSyncWithExistingConnectionAndTransactionAndOptions()
+        {
+            var tableName = DropCreate(nameof(BulkWriterTestsMyTestClass));
+            var tableNameWithKey = DropCreate(nameof(BulkWriterTestsMyTestClassWithKey));
+
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                await connection.OpenAsync();
+
+                using (var transaction = connection.BeginTransaction())
+                {
+                    var writer = new BulkWriter<BulkWriterTestsMyTestClass>(connection, transaction);
+                    var writerWithOptions = new BulkWriter<BulkWriterTestsMyTestClassWithKey>(connection, SqlBulkCopyOptions.KeepIdentity, transaction);
+
+                    var items = Enumerable.Range(11, 20).Select(i => new BulkWriterTestsMyTestClass { Id = i, Name = "Bob" });
+                    var itemsWithKey = Enumerable.Range(11, 20).Select(i => new BulkWriterTestsMyTestClassWithKey { Id = i, Name = "Bob" });
+
+                    writer.WriteToDatabase(items);
+                    writerWithOptions.WriteToDatabase(itemsWithKey);
+
+                    var minId = (int?)await TestHelpers.ExecuteScalar(connection, $"SELECT MIN(Id) FROM {tableName}", transaction);
+                    var minIdWithKey = (int?)await TestHelpers.ExecuteScalar(connection, $"SELECT MIN(Id) FROM {tableNameWithKey}", transaction);
+
+                    Assert.Equal(1, minId);
+                    Assert.Equal(11, minIdWithKey);
+
+                    transaction.Rollback();
+
+                    var emptyMinId = await TestHelpers.ExecuteScalar(connection, $"SELECT MIN(Id) FROM {tableName}");
+                    var emptyMinIdWithKey = await TestHelpers.ExecuteScalar(connection, $"SELECT MIN(Id) FROM {tableNameWithKey}");
+
+                    Assert.Equal(emptyMinId, System.DBNull.Value);
+                    Assert.Equal(emptyMinIdWithKey, System.DBNull.Value);
                 }
             }
         }


### PR DESCRIPTION
Adds constructor overloads and corresponding tests for allowing the caller to specify the SqlBulkCopyOptions when setting up the BulkWriter object.

Fixes #27 