### PR TITLE
Create baseline benchmarks for Bulk Writer

### DIFF
--- a/BulkWriter.sln
+++ b/BulkWriter.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{432DE5FB
 		setup.ps1 = setup.ps1
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BulkWriter.Benchmark", "src\BulkWriter.Benchmark\BulkWriter.Benchmark.csproj", "{C39F623C-7958-427E-B5E3-2CE704A69B85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,10 @@ Global
 		{6DAD0F01-655C-49BF-924F-01C8ED7CA62C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DAD0F01-655C-49BF-924F-01C8ED7CA62C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DAD0F01-655C-49BF-924F-01C8ED7CA62C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C39F623C-7958-427E-B5E3-2CE704A69B85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C39F623C-7958-427E-B5E3-2CE704A69B85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C39F623C-7958-427E-B5E3-2CE704A69B85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C39F623C-7958-427E-B5E3-2CE704A69B85}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BulkWriter.Benchmark/Benchmarks/BenchmarkBaseClass.cs
+++ b/src/BulkWriter.Benchmark/Benchmarks/BenchmarkBaseClass.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+namespace BulkWriter.Benchmark.Benchmarks
+{
+    public class BenchmarkBaseClass
+    {
+        [GlobalSetup]
+        public virtual void GlobalSetup()
+        {
+            using var sqlConnection = DbHelpers.OpenSqlConnection();
+            DbHelpers.TruncateTable<DomainEntity>(sqlConnection);
+        }
+
+        protected IEnumerable<DomainEntity> GetTestRecords()
+        {
+            return DataGenerationHelpers.GetDomainEntities(1000);
+        }
+    }
+}

--- a/src/BulkWriter.Benchmark/Benchmarks/BulkWriterBenchmark.cs
+++ b/src/BulkWriter.Benchmark/Benchmarks/BulkWriterBenchmark.cs
@@ -1,0 +1,93 @@
+﻿using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.SqlClient;
+
+namespace BulkWriter.Benchmark.Benchmarks
+{
+    public class BulkWriterBenchmark : BenchmarkBaseClass
+    {
+        [Benchmark]
+        public async Task BulkWriter()
+        {
+            await using var sqlConnection = DbHelpers.OpenSqlConnection();
+            using var bulkWriter = new BulkWriter<DomainEntity>(sqlConnection)
+            {
+                BulkCopyTimeout = 0,
+                BatchSize = 10000
+            };
+
+            var items = GetTestRecords();
+            await bulkWriter.WriteToDatabaseAsync(items);
+        }
+
+        [Benchmark(Baseline = true)]
+        public async Task OneRecordAtATime()
+        {
+            var tableName = DbHelpers.GetTableName<DomainEntity>();
+            var insertSql = $"INSERT INTO {tableName} (Id, FirstName, LastName) VALUES (@Id, @FirstName, @LastName)";
+
+            await using var sqlConnection = DbHelpers.OpenSqlConnection();
+
+            var records = GetTestRecords();
+            foreach (var domainEntity in records)
+            {
+                var sqlCommand = new SqlCommand(insertSql, sqlConnection);
+                sqlCommand.Parameters.AddWithValue("@Id", domainEntity.Id);
+                sqlCommand.Parameters.AddWithValue("@FirstName", domainEntity.FirstName);
+                sqlCommand.Parameters.AddWithValue("@LastName", domainEntity.LastName);
+
+                await sqlCommand.ExecuteNonQueryAsync();
+            }
+        }
+
+        [Benchmark]
+        public async Task Batched100()
+        {
+            var tableName = DbHelpers.GetTableName<DomainEntity>();
+            var insertSql = $"INSERT INTO {tableName} (Id, FirstName, LastName) VALUES ";
+
+            await using var sqlConnection = DbHelpers.OpenSqlConnection();
+
+            var batchSize = 100;
+            var currentBatchSize = 0;
+            var records = GetTestRecords();
+            
+            var queryBuilder = new StringBuilder(insertSql);
+            var sqlCommand = new SqlCommand("", sqlConnection);
+
+            foreach (var record in records)
+            {
+                queryBuilder.Append(currentBatchSize == 0
+                    ? "(@p0, @p1, @p2)"
+                    : $",(@p{currentBatchSize * 3}, @p{currentBatchSize * 3 + 1}, @p{currentBatchSize * 3 + 2})");
+
+                sqlCommand.Parameters.AddWithValue($"@p{currentBatchSize * 3}", record.Id);
+                sqlCommand.Parameters.AddWithValue($"@p{currentBatchSize * 3 + 1}", record.FirstName);
+                sqlCommand.Parameters.AddWithValue($"@p{currentBatchSize * 3 + 2}", record.LastName);
+
+                ++currentBatchSize;
+
+                if (currentBatchSize == batchSize)
+                {
+                    sqlCommand.CommandText = queryBuilder.ToString();
+                    await sqlCommand.ExecuteNonQueryAsync();
+
+                    currentBatchSize = 0;
+
+                    queryBuilder.Clear();
+                    queryBuilder.Append(insertSql);
+
+                    sqlCommand.CommandText = "";
+                    sqlCommand.Parameters.Clear();
+                }
+            }
+
+            if (currentBatchSize > 0)
+            {
+                sqlCommand.CommandText = queryBuilder.ToString();
+                await sqlCommand.ExecuteNonQueryAsync();
+            }
+        }
+    }
+}

--- a/src/BulkWriter.Benchmark/BulkWriter.Benchmark.csproj
+++ b/src/BulkWriter.Benchmark/BulkWriter.Benchmark.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BulkWriter.Benchmark/BulkWriter.Benchmark.csproj
+++ b/src/BulkWriter.Benchmark/BulkWriter.Benchmark.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BulkWriter\BulkWriter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BulkWriter.Benchmark/DataGenerationHelpers.cs
+++ b/src/BulkWriter.Benchmark/DataGenerationHelpers.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+namespace BulkWriter.Benchmark
+{
+    internal static class DataGenerationHelpers
+    {
+        private static long _idCounter = 0;
+
+        public static IEnumerable<DomainEntity> GetDomainEntities(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                yield return new DomainEntity
+                {
+                    Id = GetNextId(),
+                    FirstName = $"Bob-{i}",
+                    LastName = $"Smith-{i}"
+                };
+            }
+        }
+
+        private static long GetNextId()
+        {
+            return Interlocked.Increment(ref _idCounter);
+        }
+    }
+}

--- a/src/BulkWriter.Benchmark/DbHelpers.cs
+++ b/src/BulkWriter.Benchmark/DbHelpers.cs
@@ -1,0 +1,97 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using Microsoft.Data.SqlClient;
+
+namespace BulkWriter.Benchmark
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "No user input here")]
+    internal static class DbHelpers
+    {
+        private const string SetupConnectionString = "Data Source=.\\;Trusted_Connection=True;";
+
+        private const string ConnectionString = "Data Source=.\\;Trusted_Connection=True;Initial Catalog=BulkWriter.Benchmark";
+        private const string DbName = "BulkWriter.Benchmark";
+
+        internal static SqlConnection OpenSqlConnection()
+        {
+            var connection = new SqlConnection(ConnectionString);
+            connection.Open();
+
+            return connection;
+        }
+
+        internal static void SetupDb()
+        {
+            using var sqlConnection = new SqlConnection(SetupConnectionString);
+            sqlConnection.Open();
+
+            CreateDatabase(sqlConnection);
+            SetSimpleRecovery(sqlConnection);
+
+            DropTable<DomainEntity>(sqlConnection);
+            CreateDomainEntitiesTable(sqlConnection);
+        }
+
+        internal static void CreateDatabase(SqlConnection sqlConnection)
+        {
+            var createDatabaseSql = @$"IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'{DbName}')
+CREATE DATABASE [{DbName}]";
+            using var command = new SqlCommand(createDatabaseSql, sqlConnection);
+            command.ExecuteNonQuery();
+
+            SetDatabaseSize(sqlConnection);
+        }
+
+        internal static void SetSimpleRecovery(SqlConnection sqlConnection)
+        {
+            var alterDatabaseSql = $"ALTER DATABASE [{DbName}] SET RECOVERY SIMPLE";
+            using var command = new SqlCommand(alterDatabaseSql, sqlConnection);
+            command.ExecuteNonQuery();
+        }
+
+        internal static void SetDatabaseSize(SqlConnection sqlConnection)
+        {
+            var alterDatabaseSql = @$"IF NOT EXISTS(SELECT name FROM [{DbName}].sys.database_files WHERE [type]=0 AND size > 100000)
+ALTER DATABASE [{DbName}] MODIFY FILE (Name='{DbName}', SIZE = 1000MB)";
+            using var command = new SqlCommand(alterDatabaseSql, sqlConnection);
+            command.ExecuteNonQuery();
+        }
+
+        internal static void CreateDomainEntitiesTable(SqlConnection sqlConnection)
+        {
+            var tableName = GetTableName<DomainEntity>();
+            var createTableSql = @$"USE [{DbName}]; CREATE TABLE dbo.{tableName} (
+    [Id] [bigint] NOT NULL,
+    [FirstName] [nvarchar](100),
+    [LastName] [nvarchar](100),
+    CONSTRAINT [PK_{1}] PRIMARY KEY CLUSTERED ([Id] ASC )
+)";
+
+            using var command = new SqlCommand(createTableSql, sqlConnection);
+            command.ExecuteNonQuery();
+        }
+
+        internal static void DropTable<TEntity>(SqlConnection sqlConnection)
+        {
+            var tableName = GetTableName<TEntity>();
+            var dropTableSql = $"USE [{DbName}]; DROP TABLE IF EXISTS {tableName}";
+            using var command = new SqlCommand(dropTableSql, sqlConnection);
+            command.ExecuteNonQuery();
+        }
+
+        internal static void TruncateTable<TEntity>(SqlConnection sqlConnection)
+        {
+            var tableName = GetTableName<TEntity>();
+            var dropTableSql = $"USE [{DbName}]; TRUNCATE TABLE {tableName}";
+            using var command = new SqlCommand(dropTableSql, sqlConnection);
+            command.ExecuteNonQuery();
+        }
+
+        internal static string GetTableName<TEntity>()
+        {
+            var t = typeof(TEntity);
+            var tableNameAttribute = t.GetCustomAttribute<TableAttribute>();
+            return tableNameAttribute != null ? tableNameAttribute.Name : t.Name;
+        }
+    }
+}

--- a/src/BulkWriter.Benchmark/DomainEntity.cs
+++ b/src/BulkWriter.Benchmark/DomainEntity.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BulkWriter.Benchmark
+{
+    [Table("DomainEntities")]
+    public class DomainEntity
+    {
+        [Key]
+        public long Id { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/src/BulkWriter.Benchmark/Program.cs
+++ b/src/BulkWriter.Benchmark/Program.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace BulkWriter.Benchmark
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            DbHelpers.SetupDb();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}


### PR DESCRIPTION
This PR helps enable the work for #47 by establishing a baseline benchmark project for the library. As of now, 3 benchmarks are included for 3 different approaches to bulk loading data:

1. Naive, insert one record at a time w/ parameterized SQL
2. Batch inserts w/ parameterized SQL
3. Bulk insert using BulkWriter

Given that we're reliant heavily on the performance of SQL Server itself, I tried to setup the tests in such a way that the environment would be equivalent for each different benchmark.  For instance, the benchmark database is put into the SIMPLE recovery model and the database is established at 1 GB so we don't hit any file allocation / expansion during testing.

Only the RELEASE version of the benchmark EXE should be run for the sake of comparing actual results. See the [BenchmarkDotNet documentation](https://benchmarkdotnet.org/articles/guides/console-args.html) for available command line arguments, or run without parameters to see a test run in action.