### PR TITLE
Issue 57 Remove CLS Compliance

### DIFF
--- a/src/BulkWriter/Properties/AssemblyInfo.cs
+++ b/src/BulkWriter/Properties/AssemblyInfo.cs
@@ -15,5 +15,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d4478ca6-9e19-4372-8d21-5f90f05212c0")]
-
-[assembly: CLSCompliant(true)]


### PR DESCRIPTION
This PR removes the CLSCompiant indicator from the BulkWriter project.

The primary driver is to remove build warnings but until the package Microsoft.Data.SqlClient is CLS compliant our project would always throw the warnings. The value added by marking the project CLS compliant is not apparent at this time.

Some notable conversations on the topic: https://github.com/dotnet/aspnetcore/issues/2689#issuecomment-354693946