### PR TITLE
Pipeline task refactor

### DIFF
--- a/src/BulkWriter/Pipeline/EtlPipeline.cs
+++ b/src/BulkWriter/Pipeline/EtlPipeline.cs
@@ -44,7 +44,7 @@ namespace BulkWriter.Pipeline
         public static IEtlPipelineStep<T, T> StartWith<T>(IEnumerable<T> input)
         {
             var pipeline = new EtlPipeline();
-            var etlPipelineSetupContext = new EtlPipelineContext(pipeline, (p, s) => pipeline.AddStep(s));
+            var etlPipelineSetupContext = new EtlPipelineContext(pipeline, s => pipeline.AddStep(s));
             var step = new StartEtlPipelineStep<T>(etlPipelineSetupContext, input);
 
             etlPipelineSetupContext.AddStep(step);

--- a/src/BulkWriter/Pipeline/Internal/AggregateEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/AggregateEtlPipelineStep.cs
@@ -14,15 +14,12 @@ namespace BulkWriter.Pipeline.Internal
             _aggregationFunc = aggregationFunc ?? throw new ArgumentNullException(nameof(aggregationFunc));
         }
 
-        public override void Run(CancellationToken cancellationToken)
+        protected override void RunCore(CancellationToken cancellationToken)
         {
             var enumerable = InputCollection.GetConsumingEnumerable(cancellationToken);
 
-            RunSafely(() =>
-            {
-                var result = _aggregationFunc(enumerable);
-                OutputCollection.Add(result, cancellationToken);
-            });
+            var result = _aggregationFunc(enumerable);
+            OutputCollection.Add(result, cancellationToken);
         }
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/AggregateEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/AggregateEtlPipelineStep.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -9,7 +8,7 @@ namespace BulkWriter.Pipeline.Internal
     {
         private readonly Func<IEnumerable<TIn>, TOut> _aggregationFunc;
 
-        public AggregateEtlPipelineStep(EtlPipelineContext pipelineContext, BlockingCollection<TIn> inputCollection, Func<IEnumerable<TIn>, TOut> aggregationFunc) : base(pipelineContext, inputCollection)
+        public AggregateEtlPipelineStep(EtlPipelineStepBase<TIn> previousStep, Func<IEnumerable<TIn>, TOut> aggregationFunc) : base(previousStep)
         {
             _aggregationFunc = aggregationFunc ?? throw new ArgumentNullException(nameof(aggregationFunc));
         }

--- a/src/BulkWriter/Pipeline/Internal/BulkWriterEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/BulkWriterEtlPipelineStep.cs
@@ -12,7 +12,7 @@ namespace BulkWriter.Pipeline.Internal
             _bulkWriter = bulkWriter;
         }
 
-        public override void Run(CancellationToken cancellationToken)
+        protected override void RunCore(CancellationToken cancellationToken)
         {
             var enumerable = InputCollection.GetConsumingEnumerable(cancellationToken);
             _bulkWriter.WriteToDatabase(enumerable);

--- a/src/BulkWriter/Pipeline/Internal/BulkWriterEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/BulkWriterEtlPipelineStep.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Threading;
+﻿using System.Threading;
 
 namespace BulkWriter.Pipeline.Internal
 {
@@ -7,7 +6,7 @@ namespace BulkWriter.Pipeline.Internal
     {
         private readonly IBulkWriter<TEntity> _bulkWriter;
 
-        public BulkWriterEtlPipelineStep(EtlPipelineContext pipelineContext, BlockingCollection<TEntity> inputCollection, IBulkWriter<TEntity> bulkWriter) : base(pipelineContext, inputCollection)
+        public BulkWriterEtlPipelineStep(EtlPipelineStepBase<TEntity> previousStep, IBulkWriter<TEntity> bulkWriter) : base(previousStep)
         {
             _bulkWriter = bulkWriter;
         }

--- a/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
+++ b/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
@@ -4,9 +4,9 @@ namespace BulkWriter.Pipeline.Internal
 {
     internal class EtlPipelineContext
     {
-        private readonly Action<IEtlPipeline, IEtlPipelineStep> _addStepAction;
+        private readonly Action<IEtlPipelineStep> _addStepAction;
 
-        public EtlPipelineContext(IEtlPipeline etlPipeline, Action<IEtlPipeline, IEtlPipelineStep> addStepAction)
+        public EtlPipelineContext(IEtlPipeline etlPipeline, Action<IEtlPipelineStep> addStepAction)
         {
             Pipeline = etlPipeline;
             _addStepAction = addStepAction;
@@ -16,7 +16,7 @@ namespace BulkWriter.Pipeline.Internal
 
         public void AddStep(IEtlPipelineStep step)
         {
-            _addStepAction(Pipeline, step);
+            _addStepAction(step);
         }
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/EtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/EtlPipelineStep.cs
@@ -92,23 +92,24 @@ namespace BulkWriter.Pipeline.Internal
             return PipelineContext.Pipeline;
         }
 
-        protected void RunSafely(Action action)
+        protected abstract void RunCore(CancellationToken cancellationToken);
+
+        public void Run(CancellationToken cancellationToken)
         {
             try
             {
-                action();
+                RunCore(cancellationToken);
             }
             finally
             {
                 //This statement is in place to ensure that no matter what, the output collection
-                //will be marked "complete".  Without this, an exception in the action above can
+                //will be marked "complete". Without this, an exception in the try block above can
                 //lead to a stalled (i.e. non-terminating) pipeline because this thread's consumer
                 //is waiting for more output from this thread, which will never happen because the
-                //thread is now dead.
+                //thread is now dead. This should also ensure we get at least partial output in case
+                //of an exception.
                 OutputCollection.CompleteAdding();
             }
         }
-
-        public abstract void Run(CancellationToken cancellationToken);
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/PivotEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/PivotEtlPipelineStep.cs
@@ -14,21 +14,18 @@ namespace BulkWriter.Pipeline.Internal
             _pivotFunc = pivotFunc ?? throw new ArgumentNullException(nameof(pivotFunc));
         }
 
-        public override void Run(CancellationToken cancellationToken)
+        protected override void RunCore(CancellationToken cancellationToken)
         {
             var enumerable = InputCollection.GetConsumingEnumerable(cancellationToken);
 
-            RunSafely(() =>
+            foreach (var item in enumerable)
             {
-                foreach (var item in enumerable)
+                var outputs = _pivotFunc(item);
+                foreach (var output in outputs)
                 {
-                    var outputs = _pivotFunc(item);
-                    foreach (var output in outputs)
-                    {
-                        OutputCollection.Add(output, cancellationToken);
-                    }
+                    OutputCollection.Add(output, cancellationToken);
                 }
-            });
+            }
         }
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/PivotEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/PivotEtlPipelineStep.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -9,7 +8,7 @@ namespace BulkWriter.Pipeline.Internal
     {
         private readonly Func<TIn, IEnumerable<TOut>> _pivotFunc;
 
-        public PivotEtlPipelineStep(EtlPipelineContext pipelineContext, BlockingCollection<TIn> inputCollection, Func<TIn, IEnumerable<TOut>> pivotFunc) : base(pipelineContext, inputCollection)
+        public PivotEtlPipelineStep(EtlPipelineStepBase<TIn> previousStep, Func<TIn, IEnumerable<TOut>> pivotFunc) : base(previousStep)
         {
             _pivotFunc = pivotFunc ?? throw new ArgumentNullException(nameof(pivotFunc));
         }

--- a/src/BulkWriter/Pipeline/Internal/ProjectEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/ProjectEtlPipelineStep.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace BulkWriter.Pipeline.Internal
@@ -8,7 +7,7 @@ namespace BulkWriter.Pipeline.Internal
     {
         private readonly Func<TIn, TOut> _projectionFunc;
 
-        public ProjectEtlPipelineStep(EtlPipelineContext pipelineContext, BlockingCollection<TIn> inputCollection, Func<TIn, TOut> projectionFunc) : base(pipelineContext, inputCollection)
+        public ProjectEtlPipelineStep(EtlPipelineStepBase<TIn> previousStep, Func<TIn, TOut> projectionFunc) : base(previousStep)
         {
             _projectionFunc = projectionFunc ?? throw new ArgumentNullException(nameof(projectionFunc));
         }

--- a/src/BulkWriter/Pipeline/Internal/ProjectEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/ProjectEtlPipelineStep.cs
@@ -13,18 +13,15 @@ namespace BulkWriter.Pipeline.Internal
             _projectionFunc = projectionFunc ?? throw new ArgumentNullException(nameof(projectionFunc));
         }
 
-        public override void Run(CancellationToken cancellationToken)
+        protected override void RunCore(CancellationToken cancellationToken)
         {
             var enumerable = InputCollection.GetConsumingEnumerable(cancellationToken);
 
-            RunSafely(() =>
+            foreach (var item in enumerable)
             {
-                foreach (var item in enumerable)
-                {
-                    var result = _projectionFunc(item);
-                    OutputCollection.Add(result, cancellationToken);
-                }
-            });
+                var result = _projectionFunc(item);
+                OutputCollection.Add(result, cancellationToken);
+            }
         }
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/StartEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/StartEtlPipelineStep.cs
@@ -13,15 +13,12 @@ namespace BulkWriter.Pipeline.Internal
             _inputEnumerable = inputEnumerable;
         }
 
-        public override void Run(CancellationToken cancellationToken)
+        protected override void RunCore(CancellationToken cancellationToken)
         {
-            RunSafely(() =>
+            foreach (var item in _inputEnumerable)
             {
-                foreach (var item in _inputEnumerable)
-                {
-                    OutputCollection.Add(item, cancellationToken);
-                }
-            });
+                OutputCollection.Add(item, cancellationToken);
+            }
         }
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/StartEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/StartEtlPipelineStep.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 
 namespace BulkWriter.Pipeline.Internal
@@ -8,7 +7,7 @@ namespace BulkWriter.Pipeline.Internal
     {
         private readonly IEnumerable<TIn> _inputEnumerable;
 
-        public StartEtlPipelineStep(EtlPipelineContext pipelineContext, IEnumerable<TIn> inputEnumerable) : base(pipelineContext, new BlockingCollection<TIn>())
+        public StartEtlPipelineStep(EtlPipelineContext pipelineContext, IEnumerable<TIn> inputEnumerable) : base(pipelineContext)
         {
             _inputEnumerable = inputEnumerable;
         }

--- a/src/BulkWriter/Pipeline/Internal/TransformEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/TransformEtlPipelineStep.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace BulkWriter.Pipeline.Internal
@@ -8,7 +7,7 @@ namespace BulkWriter.Pipeline.Internal
     {
         private readonly Action<TOut>[] _transformActions;
 
-        public TransformEtlPipelineStep(EtlPipelineContext pipelineContext, BlockingCollection<TOut> inputCollection, params Action<TOut>[] transformActions) : base(pipelineContext, inputCollection)
+        public TransformEtlPipelineStep(EtlPipelineStepBase<TOut> previousStep, params Action<TOut>[] transformActions) : base(previousStep)
         {
             _transformActions = transformActions;
         }

--- a/src/BulkWriter/Pipeline/Internal/TransformEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Internal/TransformEtlPipelineStep.cs
@@ -13,22 +13,19 @@ namespace BulkWriter.Pipeline.Internal
             _transformActions = transformActions;
         }
 
-        public override void Run(CancellationToken cancellationToken)
+        protected override void RunCore(CancellationToken cancellationToken)
         {
             var enumerable = InputCollection.GetConsumingEnumerable(cancellationToken);
 
-            RunSafely(() =>
+            foreach (var item in enumerable)
             {
-                foreach (var item in enumerable)
+                foreach (var transformAction in _transformActions)
                 {
-                    foreach (var transformAction in _transformActions)
-                    {
-                        transformAction(item);
-                    }
-
-                    OutputCollection.Add(item, cancellationToken);
+                    transformAction(item);
                 }
-            });
+
+                OutputCollection.Add(item, cancellationToken);
+            }
         }
     }
 }


### PR DESCRIPTION
Modifies the public `EtlPipeline` implementation to return a parent task with a `Task` for every step in the pipeline, rather than just the final task. Exceptions in any pipeline step will now be bubbled up to caller where before they were swallowed (except for the BulkWriter step).

This PR also modifies the internals of the pipeline setup so that steps are now more explicitly chained together at step construction by passing in each new step's preceding step.

Finally, all steps now have the same shared `Run` implementation, allowing the `RunSafely` method to be removed.  The only step that wasn't using `RunSafely` was the BulkWriter step, presumably because it doesn't need to ensure its `OutputCollection` is marked complete since there's nothing on the other end, which is why marking it complete is also a safe action in all cases. This results in a slightly simpler implementation.