### PR TITLE
Add basic logging to pipeline internals

### DIFF
--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\logo.png" Pack="true" PackagePath="\" />

--- a/src/BulkWriter/BulkWriter.csproj
+++ b/src/BulkWriter/BulkWriter.csproj
@@ -21,6 +21,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />

--- a/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
+++ b/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
@@ -5,12 +5,12 @@ namespace BulkWriter.Pipeline.Internal
 {
     internal class EtlPipelineContext
     {
-        private readonly Action<IEtlPipelineStep> _addStepAction;
+        private readonly Action<IEtlPipelineStep> _addStepToPipelineAction;
 
-        public EtlPipelineContext(IEtlPipeline etlPipeline, Action<IEtlPipelineStep> addStepAction)
+        public EtlPipelineContext(IEtlPipeline etlPipeline, Action<IEtlPipelineStep> addStepToPipelineAction)
         {
             Pipeline = etlPipeline;
-            _addStepAction = addStepAction;
+            _addStepToPipelineAction = addStepToPipelineAction;
         }
 
         public IEtlPipeline Pipeline { get; }
@@ -18,7 +18,7 @@ namespace BulkWriter.Pipeline.Internal
 
         public void AddStep(IEtlPipelineStep step)
         {
-            _addStepAction(step);
+            _addStepToPipelineAction(step);
         }
     }
 }

--- a/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
+++ b/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 
 namespace BulkWriter.Pipeline.Internal
 {
@@ -13,6 +14,7 @@ namespace BulkWriter.Pipeline.Internal
         }
 
         public IEtlPipeline Pipeline { get; }
+        public ILoggerFactory LoggerFactory { get; set; }
 
         public void AddStep(IEtlPipelineStep step)
         {

--- a/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
+++ b/src/BulkWriter/Pipeline/Internal/EtlPipelineContext.cs
@@ -15,9 +15,11 @@ namespace BulkWriter.Pipeline.Internal
 
         public IEtlPipeline Pipeline { get; }
         public ILoggerFactory LoggerFactory { get; set; }
+        public int TotalSteps { get; private set; }
 
         public void AddStep(IEtlPipelineStep step)
         {
+            ++TotalSteps;
             _addStepToPipelineAction(step);
         }
     }

--- a/src/BulkWriter/Pipeline/Steps/IEtlPipelineStep.cs
+++ b/src/BulkWriter/Pipeline/Steps/IEtlPipelineStep.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using BulkWriter.Pipeline.Transforms;
+using Microsoft.Extensions.Logging;
 
 namespace BulkWriter.Pipeline.Steps
 {
@@ -72,6 +73,13 @@ namespace BulkWriter.Pipeline.Steps
         /// <param name="transformActions">One or more actions that will transform input objects in place</param>
         /// <returns>Next step in the pipeline to be configured</returns>
         IEtlPipelineStep<TOut, TOut> TransformInPlace(params Action<TOut>[] transformActions);
+
+        /// <summary>
+        /// Enables logging of the ETL pipeline internals
+        /// </summary>
+        /// <param name="loggerFactory">Factory used to create a new ILogger</param>
+        /// <returns>Current step in the pipeline</returns>
+        IEtlPipelineStep<TIn, TOut> LogWith(ILoggerFactory loggerFactory);
 
         /// <summary>
         /// Configures the pipeline to write its output to a BulkWriter object; finalizes the pipeline.


### PR DESCRIPTION
Modifies the public fluent configuration interface for pipelines to allow the user to pass in an `ILoggerFactory`.  This factory is used in each pipeline step to create an `ILogger` instance for logging the step start, end and unhandled exceptions.

Note that this does not provide a facility for logging the internals of the user-supplied pipeline code.  This can be accomplished in other ways:

- Actions/Funcs provided by the user can capture or create loggers themselves
- User-supplied implementations of the various transform interfaces could be created with their own logger dependencies

Resolves #60